### PR TITLE
Implement continuous deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,23 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script: |
+            cd ${{ secrets.VPS_PATH }}
+            git pull
+            npm ci --omit=dev
+            npm run build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: Deployment
 
     steps:
       - name: Deploy to VPS

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
-            cd ${{ secrets.VPS_PATH }}
+            cd ${{ secrets.VPS_APP_PATH }}
             git pull
             npm ci --omit=dev
             npm run build


### PR DESCRIPTION
## Summary
- Add `.github/workflows/cd.yml` that triggers on push to `main`
- SSH into VPS using `appleboy/ssh-action`, runs `git pull`, `npm ci --omit=dev`, `npm run build`

## Required secrets (set in repo Settings → Secrets)
- `VPS_HOST` — `62.171.180.166`
- `VPS_USER` — SSH username
- `VPS_SSH_KEY` — private key content
- `VPS_PATH` — absolute path to repo on server

## Test plan
- [ ] Add secrets to GitHub repo
- [ ] Merge PR and verify Actions tab shows successful deploy run

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)