### PR TITLE
Implement continuous deployment

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,8 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             cd ${{ secrets.VPS_APP_PATH }}
             git pull
             npm ci --omit=dev


### PR DESCRIPTION
## Summary
- Add `.github/workflows/cd.yml` triggered on push to `main`
- SSH into VPS via `appleboy/ssh-action`, runs `git pull`, `npm ci --omit=dev`, `npm run build`
- Source nvm before npm commands to fix `npm: command not found` in non-interactive SSH sessions

## Required secrets (repo Settings → Environments → Deployment)
- `VPS_HOST` — `62.171.180.166`
- `VPS_USER` — SSH username
- `VPS_SSH_KEY` — private key content
- `VPS_APP_PATH` — absolute path to repo on server

## Test plan
- [ ] Verify secrets are set in `Deployment` environment
- [ ] Merge and confirm Actions run succeeds

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)