### PR TITLE
Fix CD: install devDeps and disable husky

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,5 +22,5 @@ jobs:
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             cd ${{ secrets.VPS_APP_PATH }}
             git pull
-            npm ci --omit=dev
+            HUSKY=0 npm ci
             npm run build


### PR DESCRIPTION
## Problem
Deploy was failing with two errors:
- `husky: not found` — `prepare` lifecycle script runs husky, which was excluded by `--omit=dev`
- `tsc: not found` — typescript is a devDependency required for the build step

## Fix
- Remove `--omit=dev` so devDependencies (including `typescript`) are installed
- Set `HUSKY=0` to skip the `prepare` script in the deploy environment

## Test plan
- [ ] Merge and confirm Actions CD run succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)